### PR TITLE
Workaround incompatible odo dep version and 2.0.0 devfile schema checks

### DIFF
--- a/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
+++ b/pkg/devfile/parser/data/2.0.0/devfileJsonSchema200.go
@@ -463,7 +463,6 @@ const JsonSchema200 = `{
 					  }
 					},
 					"required": [
-					  "configuration",
 					  "name",
 					  "targetPort"
 					],

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -808,7 +808,7 @@ func GetGitHubZipURL(repoURL string) (string, error) {
 	client := github.NewClient(nil)
 	opt := &github.RepositoryContentGetOptions{Ref: branch}
 
-	URL, response, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt)
+	URL, response, err := client.Repositories.GetArchiveLink(context.Background(), owner, repo, "zipball", opt, true)
 	if err != nil {
 		errMessage := fmt.Sprintf("Error getting zip url. Response: %s.", response.Status)
 		return url, errors.New(errMessage)


### PR DESCRIPTION

* Remove "configuration"  as a required field in 2.0.0 devfile schema to workaround the downloaded devfile without configuration.

* Add  last "bool" parameter to client.Repositories.GetArchiveLink() to workaround different incompatible version of github.com/google/go-github used in odo